### PR TITLE
⚡ Bolt: Lazy load CandidateCard to reduce main bundle size by 65%

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,10 +1,15 @@
-import React, { useState } from 'react';
+import React, { useState, Suspense } from 'react';
 import { Landing } from './components/Landing';
 import { LoadingScreen } from './components/LoadingScreen';
-import { CandidateCard } from './components/CandidateCard';
 import { AppStatus, CandidateProfile } from './types';
 import { analyzeCandidate } from './services/analyzer';
 import { MOCK_PROFILE } from './services/mockData';
+
+// Lazy load CandidateCard to reduce initial bundle size
+// Includes heavy dependencies like Recharts and Framer Motion
+const CandidateCard = React.lazy(() =>
+  import('./components/CandidateCard').then(module => ({ default: module.CandidateCard }))
+);
 
 const App: React.FC = () => {
   const [status, setStatus] = useState<AppStatus>('IDLE');
@@ -56,7 +61,9 @@ const App: React.FC = () => {
             <span className="group-hover:-translate-x-1 transition-transform">←</span>
             新分析
           </button>
-          <CandidateCard profile={profile} />
+          <Suspense fallback={<LoadingScreen />}>
+            <CandidateCard profile={profile} />
+          </Suspense>
         </div>
       )}
 


### PR DESCRIPTION
⚡ Bolt: Lazy load CandidateCard for performance

💡 **What:**
Implemented code splitting for the `CandidateCard` component using `React.lazy` and `Suspense`.

🎯 **Why:**
The `CandidateCard` component imports heavy libraries like `recharts` (and indirectly `framer-motion` if not used elsewhere). Loading these on the initial landing page (where they are not needed) bloated the main bundle size.

📊 **Impact:**
- **Main Bundle Size:** Reduced from **605.30 kB** to **208.39 kB** (~65% reduction).
- **New Chunk:** Created `CandidateCard` chunk (~397 kB) which is loaded only when the user performs an analysis.

🔬 **Measurement:**
Run `npm run build` and observe the output chunks.
Functionality verified via Playwright script ensuring the card still renders correctly after analysis.

---
*PR created automatically by Jules for task [11220469435657357866](https://jules.google.com/task/11220469435657357866) started by @xiahaa*