### PR TITLE
🛡️ Sentinel: Add input validation for analysis context

### DIFF
--- a/services/analyzer.test.ts
+++ b/services/analyzer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseGitHubUsername } from './analyzer';
+import { parseGitHubUsername, validateScholarUrl, sanitizeInputText } from './analyzer';
 
 describe('parseGitHubUsername', () => {
   it('should accept valid usernames from URLs', () => {
@@ -29,5 +29,37 @@ describe('parseGitHubUsername', () => {
   // are interpreted as hostnames by the URL constructor, resulting in an empty string.
   it('should return empty for simple username input (current limitation)', () => {
     expect(parseGitHubUsername('torvalds')).toBe('');
+  });
+});
+
+describe('validateScholarUrl', () => {
+  it('should accept valid http/https URLs', () => {
+    expect(validateScholarUrl('https://scholar.google.com/citations?user=123')).toBe('https://scholar.google.com/citations?user=123');
+    expect(validateScholarUrl('http://scholar.google.com/citations?user=123')).toBe('http://scholar.google.com/citations?user=123');
+  });
+
+  it('should reject invalid URLs', () => {
+    expect(validateScholarUrl('not-a-url')).toBeUndefined();
+    expect(validateScholarUrl('ftp://scholar.google.com')).toBeUndefined();
+    expect(validateScholarUrl('')).toBeUndefined();
+  });
+
+  it('should reject dangerous schemes', () => {
+    expect(validateScholarUrl('javascript:alert(1)')).toBeUndefined();
+    expect(validateScholarUrl('data:text/html,alert(1)')).toBeUndefined();
+  });
+});
+
+describe('sanitizeInputText', () => {
+  it('should return original text if within limit', () => {
+    expect(sanitizeInputText('hello', 10)).toBe('hello');
+  });
+
+  it('should truncate text if exceeding limit', () => {
+    expect(sanitizeInputText('hello world', 5)).toBe('hello');
+  });
+
+  it('should handle empty input', () => {
+    expect(sanitizeInputText('', 10)).toBe('');
   });
 });

--- a/services/analyzer.ts
+++ b/services/analyzer.ts
@@ -33,6 +33,24 @@ function selectDeepSeekModel(context: Record<string, unknown>): string {
   return complexityScore >= 6 ? reasonerModel : chatModel;
 }
 
+export function validateScholarUrl(url: string): string | undefined {
+  if (!url || !url.trim()) return undefined;
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return url;
+    }
+  } catch {
+    // invalid url
+  }
+  return undefined;
+}
+
+export function sanitizeInputText(text: string, maxLength: number): string {
+  if (!text) return '';
+  return text.slice(0, maxLength);
+}
+
 export function parseGitHubUsername(githubUrl: string): string {
   const trimmed = githubUrl.trim();
   if (!trimmed) return "";
@@ -255,8 +273,8 @@ export async function analyzeCandidate(
     })),
     languageStatistics: languageStats,
     repoCountByLanguage: repoCount,
-    additionalContext: linkedinText || '',
-    scholar: scholarUrl || 'None'
+    additionalContext: sanitizeInputText(linkedinText || '', 10000),
+    scholar: validateScholarUrl(scholarUrl || '') || 'None'
   };
 
   // 4. Run DeepSeek analysis with fallback tech stack


### PR DESCRIPTION
This PR enhances the security of the application by adding input validation for user-provided data sent to the LLM analysis service.

**Changes:**
1.  **Scholar URL Validation:** Added `validateScholarUrl` to verify that provided URLs are valid and use safe protocols (`http` or `https`). This prevents injection of dangerous schemes (e.g., `javascript:`).
2.  **Input Truncation:** Added `sanitizeInputText` to limit the length of the "LinkedIn Context" field to 10,000 characters. This mitigates potential DoS risks and prevents excessive token consumption/costs when calling the DeepSeek API.
3.  **Tests:** Added comprehensive unit tests to `services/analyzer.test.ts` covering valid and invalid inputs.

**Verification:**
-   Run `npm test` to verify all tests pass, including the new validation tests.
-   Manual verification (if applicable) involves trying to submit invalid URLs or extremely long text, which should now be handled gracefully.

---
*PR created automatically by Jules for task [3585584886806372466](https://jules.google.com/task/3585584886806372466) started by @xiahaa*