### PR TITLE
⚡ Bolt: Implement client-side caching for analysis results

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2025-02-18 - Sequential API Calls with Artificial Delay
 **Learning:** Found a severe bottleneck in `services/github.ts` where 30 GitHub API requests were made sequentially with a 100ms delay between each, causing ~5-10s load times.
 **Action:** Always check for sequential `await` loops in data fetching logic. Replaced with batched `Promise.all` (concurrency 5) to respect rate limits while improving speed by ~15x.
+## 2025-02-18 - Client-Side APIs in Node Environment
+**Learning:** Codebase uses Vite for client-side but Vitest tests run in Node environment by default. `localStorage` is available in production (browser) but must be mocked or checked in tests/SSR.
+**Action:** Always wrap browser-specific APIs (localStorage, window) in checks or try-catch blocks to prevent test failures or server-side crashes.

--- a/services/analyzer.test.ts
+++ b/services/analyzer.test.ts
@@ -1,5 +1,40 @@
-import { describe, it, expect } from 'vitest';
-import { parseGitHubUsername, validateScholarUrl, sanitizeInputText } from './analyzer';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { parseGitHubUsername, validateScholarUrl, sanitizeInputText, getCacheKey, analyzeCandidate } from './analyzer';
+import * as github from './github';
+
+// Mock github services
+vi.mock('./github', () => ({
+  fetchGitHubProfile: vi.fn(),
+  fetchGitHubRepos: vi.fn(),
+  searchForEmail: vi.fn(),
+  aggregateLanguageStats: vi.fn(),
+  calculateTechStackFromLanguages: vi.fn(),
+}));
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] || null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value.toString();
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+  };
+})();
+
+// Polyfill localStorage
+if (typeof global.localStorage === 'undefined') {
+  Object.defineProperty(global, 'localStorage', {
+    value: localStorageMock,
+    writable: true // allow tests to override if needed
+  });
+}
 
 describe('parseGitHubUsername', () => {
   it('should accept valid usernames from URLs', () => {
@@ -61,5 +96,66 @@ describe('sanitizeInputText', () => {
 
   it('should handle empty input', () => {
     expect(sanitizeInputText('', 10)).toBe('');
+  });
+});
+
+describe('Caching Logic', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    localStorage.clear();
+  });
+
+  it('should generate consistent cache keys', () => {
+    const key1 = getCacheKey('user1', 'http://scholar.com', 'linkedin info');
+    const key2 = getCacheKey('user1', 'http://scholar.com', 'linkedin info');
+    expect(key1).toBe(key2);
+  });
+
+  it('should generate different keys for different inputs', () => {
+    const key1 = getCacheKey('user1', 'http://scholar.com', 'linkedin info');
+    const key2 = getCacheKey('user2', 'http://scholar.com', 'linkedin info');
+    const key3 = getCacheKey('user1', 'http://other.com', 'linkedin info');
+    expect(key1).not.toBe(key2);
+    expect(key1).not.toBe(key3);
+  });
+
+  it('should return cached profile if available and valid', async () => {
+    const username = 'cachedUser';
+    const mockProfile = { username, name: 'Cached User' };
+    const cacheKey = getCacheKey(username);
+
+    // Seed cache
+    localStorage.setItem(cacheKey, JSON.stringify({
+      timestamp: Date.now(),
+      data: mockProfile
+    }));
+
+    const result = await analyzeCandidate('https://github.com/cachedUser');
+
+    expect(result).toEqual(mockProfile);
+    expect(github.fetchGitHubProfile).not.toHaveBeenCalled();
+  });
+
+  it('should attempt to fetch fresh data if cache is expired', async () => {
+    const username = 'expiredUser';
+    const mockProfile = { username, name: 'Expired User' };
+    const cacheKey = getCacheKey(username);
+
+    // Seed expired cache (25 hours old)
+    localStorage.setItem(cacheKey, JSON.stringify({
+      timestamp: Date.now() - (25 * 60 * 60 * 1000),
+      data: mockProfile
+    }));
+
+    // Mock fetchGitHubProfile to throw an error so we can verify it was called
+    // (and stop execution before hitting other dependencies)
+    vi.mocked(github.fetchGitHubProfile).mockImplementationOnce(() => {
+      throw new Error('Fetch called');
+    });
+
+    await expect(analyzeCandidate('https://github.com/expiredUser'))
+      .rejects.toThrow('Fetch called');
+
+    expect(github.fetchGitHubProfile).toHaveBeenCalled();
   });
 });

--- a/services/analyzer.ts
+++ b/services/analyzer.ts
@@ -10,6 +10,57 @@ import {
 
 type AiAnalysis = Omit<CandidateProfile, "username" | "avatarUrl" | "location" | "email" | "topRepositories">;
 
+const CACHE_PREFIX = 'gittalent_v1_';
+const CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours
+
+export function getCacheKey(username: string, scholarUrl?: string, linkedinText?: string): string {
+  // Simple hash for text content
+  const hashText = (text: string) => {
+    let hash = 0;
+    for (let i = 0; i < text.length; i++) {
+      const char = text.charCodeAt(i);
+      hash = ((hash << 5) - hash) + char;
+      hash = hash & hash;
+    }
+    return hash;
+  };
+
+  const scholarHash = scholarUrl ? hashText(scholarUrl) : '0';
+  const linkedinHash = linkedinText ? hashText(linkedinText) : '0';
+  return `${CACHE_PREFIX}${username}_${scholarHash}_${linkedinHash}`;
+}
+
+function getCachedProfile(key: string): CandidateProfile | null {
+  try {
+    if (typeof localStorage === 'undefined') return null;
+    const cached = localStorage.getItem(key);
+    if (!cached) return null;
+
+    const { timestamp, data } = JSON.parse(cached);
+    if (Date.now() - timestamp > CACHE_TTL) {
+      localStorage.removeItem(key);
+      return null;
+    }
+
+    return data as CandidateProfile;
+  } catch (err) {
+    console.warn('Error reading from cache:', err);
+    return null;
+  }
+}
+
+function saveCachedProfile(key: string, data: CandidateProfile) {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.setItem(key, JSON.stringify({
+      timestamp: Date.now(),
+      data
+    }));
+  } catch (err) {
+    console.warn('Error saving to cache:', err);
+  }
+}
+
 function selectDeepSeekModel(context: Record<string, unknown>): string {
   const chatModel = process.env.DEEPSEEK_CHAT_MODEL || "deepseek-chat";
   const reasonerModel = process.env.DEEPSEEK_REASONER_MODEL || "deepseek-reasoner";
@@ -242,6 +293,14 @@ export async function analyzeCandidate(
   const username = parseGitHubUsername(githubUrl);
   if (!username) throw new Error('Invalid GitHub URL');
 
+  // Check cache
+  const cacheKey = getCacheKey(username, scholarUrl, linkedinText);
+  const cached = getCachedProfile(cacheKey);
+  if (cached) {
+    console.log('Returning cached profile for:', username);
+    return cached;
+  }
+
   // 1. Fetch real raw data
   const [profileData, reposData, email] = await Promise.all([
     fetchGitHubProfile(username),
@@ -304,7 +363,7 @@ export async function analyzeCandidate(
   }
 
   // 6. Merge data for final profile
-  return {
+  const finalProfile = {
     ...aiResult,
     username,
     avatarUrl: profileData.avatar_url,
@@ -320,4 +379,9 @@ export async function analyzeCandidate(
       updatedAt: r.updated_at
     }))
   };
+
+  // Save to cache
+  saveCachedProfile(cacheKey, finalProfile);
+
+  return finalProfile;
 }


### PR DESCRIPTION
Implemented client-side caching using `localStorage` to store analysis results for 24 hours. This significantly improves performance for repeated analyses of the same profile by avoiding redundant calls to GitHub and DeepSeek APIs. Added safety checks for non-browser environments and comprehensive tests.

---
*PR created automatically by Jules for task [12825447547435185391](https://jules.google.com/task/12825447547435185391) started by @xiahaa*