### PR TITLE
🛡️ Sentinel: [HIGH] Fix Client-Side SSRF in Website Analysis

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** User-controlled website/blog URL from GitHub profile was used directly in `href` without sanitization, allowing `javascript:` XSS payloads.
 **Learning:** External data sources (like GitHub API) must be treated as untrusted. Even "safe" platforms allow users to input dangerous data.
 **Prevention:** Always sanitize URLs used in `href` attributes. Use `sanitizeUrl` (which enforces http/https) for any user-provided link.
+
+## 2025-02-18 - Client-Side SSRF in URL Analysis
+**Vulnerability:** Application fetched user-provided URLs without validating if they pointed to internal network resources (localhost, 192.168.x.x), allowing potential reconnaissance of local services.
+**Learning:** Even client-side fetches are subject to SSRF risks if the user is tricked into analyzing a malicious profile that targets their own local network.
+**Prevention:** Implement strict hostname validation that blocks private IP ranges and localhost before initiating any fetch requests.

--- a/services/website.test.ts
+++ b/services/website.test.ts
@@ -182,6 +182,17 @@ describe('validatePersonalWebsiteUrl', () => {
     expect(validatePersonalWebsiteUrl('')).toBeNull();
     expect(validatePersonalWebsiteUrl('   ')).toBeNull();
   });
+
+  it('should reject private IP addresses and localhost', () => {
+    expect(validatePersonalWebsiteUrl('http://localhost')).toBeNull();
+    expect(validatePersonalWebsiteUrl('http://localhost:8080')).toBeNull();
+    expect(validatePersonalWebsiteUrl('http://127.0.0.1')).toBeNull();
+    expect(validatePersonalWebsiteUrl('http://192.168.1.1')).toBeNull();
+    expect(validatePersonalWebsiteUrl('http://10.0.0.1')).toBeNull();
+    expect(validatePersonalWebsiteUrl('http://172.16.0.1')).toBeNull();
+    expect(validatePersonalWebsiteUrl('http://[::1]')).toBeNull();
+    expect(validatePersonalWebsiteUrl('http://my-macbook.local')).toBeNull();
+  });
 });
 
 describe('checkRobotsTxt', () => {

--- a/services/website.ts
+++ b/services/website.ts
@@ -231,6 +231,55 @@ export function extractSkills(textContent: string): string[] {
 }
 
 /**
+ * Check if a hostname is a private IP address or local domain
+ * Prevents SSRF attacks on local networks
+ */
+export function isPrivateHostname(hostname: string): boolean {
+  // Check for localhost and local domains
+  if (hostname === 'localhost' || hostname.endsWith('.local') || hostname.endsWith('.localhost')) {
+    return true;
+  }
+
+  // IPv6 check for localhost
+  if (hostname === '[::1]' || hostname === '::1') {
+    return true;
+  }
+
+  // IPv4 check
+  // Matches 1.2.3.4 format
+  const ipv4Regex = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
+  const match = hostname.match(ipv4Regex);
+
+  if (match) {
+    const parts = match.slice(1).map(Number);
+    // Check for valid byte range 0-255
+    if (parts.some(p => p < 0 || p > 255)) return false;
+
+    const [a, b] = parts;
+
+    // 127.0.0.0/8 (Loopback)
+    if (a === 127) return true;
+
+    // 10.0.0.0/8 (Private)
+    if (a === 10) return true;
+
+    // 192.168.0.0/16 (Private)
+    if (a === 192 && b === 168) return true;
+
+    // 172.16.0.0/12 (Private)
+    if (a === 172 && b >= 16 && b <= 31) return true;
+
+    // 169.254.0.0/16 (Link-local)
+    if (a === 169 && b === 254) return true;
+
+    // 0.0.0.0/8 (Current network)
+    if (a === 0) return true;
+  }
+
+  return false;
+}
+
+/**
  * Validate and sanitize a personal website URL
  */
 export function validatePersonalWebsiteUrl(url: string): string | null {
@@ -260,6 +309,13 @@ export function validatePersonalWebsiteUrl(url: string): string | null {
       return null;
     }
 
+    const hostname = parsed.hostname.toLowerCase();
+
+    // Security: Block private IP addresses and localhost to prevent SSRF
+    if (isPrivateHostname(hostname)) {
+      return null;
+    }
+
     // Block known platforms that are already handled elsewhere
     const blockedDomains = [
       'github.com',
@@ -272,7 +328,6 @@ export function validatePersonalWebsiteUrl(url: string): string | null {
       'instagram.com'
     ];
 
-    const hostname = parsed.hostname.toLowerCase();
     for (const blocked of blockedDomains) {
       if (hostname === blocked || hostname.endsWith('.' + blocked)) {
         return null;


### PR DESCRIPTION
* 🚨 Severity: HIGH
* 💡 Vulnerability: Client-Side Server-Side Request Forgery (SSRF) allowing access to internal network resources via user-provided URLs.
* 🎯 Impact: Attackers could trick users into scanning their local network (localhost, 192.168.x.x) by providing malicious URLs in candidate profiles.
* 🔧 Fix: Added `isPrivateHostname` check to `validatePersonalWebsiteUrl` to block private IP ranges (RFC 1918) and localhost.
* ✅ Verification: Added comprehensive tests in `services/website.test.ts` verifying rejection of private IPs.

---
*PR created automatically by Jules for task [4210945543736040541](https://jules.google.com/task/4210945543736040541) started by @xiahaa*