### PR TITLE
🛡️ Sentinel: Enhance SSRF protection by normalizing hostnames

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Application fetched user-provided URLs without validating if they pointed to internal network resources (localhost, 192.168.x.x), allowing potential reconnaissance of local services.
 **Learning:** Even client-side fetches are subject to SSRF risks if the user is tricked into analyzing a malicious profile that targets their own local network.
 **Prevention:** Implement strict hostname validation that blocks private IP ranges and localhost before initiating any fetch requests.
+
+## 2025-02-18 - SSRF Bypass via IP Normalization
+**Vulnerability:** Private IP checks relied on strict regex matching (e.g. `127.0.0.1`), allowing bypasses using alternative formats like `127.1`, octal, or hex IPs.
+**Learning:** Attackers can represent IPs in many valid formats that simple regexes miss. The browser/OS resolves them to the same target.
+**Prevention:** Normalize hostnames using `new URL(url).hostname` before applying security checks. This converts obscure formats (e.g. `0x7f.0.0.1`) to standard dotted-decimal notation.

--- a/services/website.test.ts
+++ b/services/website.test.ts
@@ -7,10 +7,35 @@ import {
   extractSkills,
   validatePersonalWebsiteUrl,
   checkRobotsTxt,
-  fetchPersonalWebsite
+  fetchPersonalWebsite,
+  isPrivateHostname
 } from './website';
 
 const originalFetch = global.fetch;
+
+describe('isPrivateHostname', () => {
+  it('should identify standard private hostnames', () => {
+    expect(isPrivateHostname('127.0.0.1')).toBe(true);
+    expect(isPrivateHostname('localhost')).toBe(true);
+    expect(isPrivateHostname('192.168.1.1')).toBe(true);
+    expect(isPrivateHostname('10.0.0.1')).toBe(true);
+    expect(isPrivateHostname('169.254.1.1')).toBe(true);
+    expect(isPrivateHostname('[::1]')).toBe(true);
+  });
+
+  it('should identify alternative IPv4 formats as private', () => {
+    expect(isPrivateHostname('127.1')).toBe(true);
+    expect(isPrivateHostname('0177.0.0.1')).toBe(true);
+    expect(isPrivateHostname('2130706433')).toBe(true); // Decimal 127.0.0.1
+    expect(isPrivateHostname('0x7f.0.0.1')).toBe(true);
+  });
+
+  it('should identify public hostnames', () => {
+    expect(isPrivateHostname('google.com')).toBe(false);
+    expect(isPrivateHostname('8.8.8.8')).toBe(false);
+    expect(isPrivateHostname('example.com')).toBe(false);
+  });
+});
 
 describe('parseRobotsTxt', () => {
   it('should allow scraping when robots.txt allows all', () => {

--- a/services/website.ts
+++ b/services/website.ts
@@ -235,20 +235,30 @@ export function extractSkills(textContent: string): string[] {
  * Prevents SSRF attacks on local networks
  */
 export function isPrivateHostname(hostname: string): boolean {
+  // Normalize hostname to handle short/hex/octal IP formats (e.g. 127.1 -> 127.0.0.1)
+  let normalizedHostname = hostname;
+  try {
+    // Prepend protocol if missing to satisfy URL constructor
+    const urlStr = hostname.includes('://') ? hostname : `http://${hostname}`;
+    normalizedHostname = new URL(urlStr).hostname;
+  } catch {
+    // If parsing fails, continue with original hostname
+  }
+
   // Check for localhost and local domains
-  if (hostname === 'localhost' || hostname.endsWith('.local') || hostname.endsWith('.localhost')) {
+  if (normalizedHostname === 'localhost' || normalizedHostname.endsWith('.local') || normalizedHostname.endsWith('.localhost')) {
     return true;
   }
 
   // IPv6 check for localhost
-  if (hostname === '[::1]' || hostname === '::1') {
+  if (normalizedHostname === '[::1]' || normalizedHostname === '::1') {
     return true;
   }
 
   // IPv4 check
   // Matches 1.2.3.4 format
   const ipv4Regex = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
-  const match = hostname.match(ipv4Regex);
+  const match = normalizedHostname.match(ipv4Regex);
 
   if (match) {
     const parts = match.slice(1).map(Number);


### PR DESCRIPTION
Enhances the `isPrivateHostname` utility to normalize hostnames using the URL API before validation. This prevents SSRF bypasses using alternative IPv4 formats (e.g., `127.1`, `0x7f.0.0.1`, `0177.0.0.1`) which resolve to local addresses but might evade simple regex checks.
Also adds comprehensive test cases to `services/website.test.ts` to verify protection against these formats.

---
*PR created automatically by Jules for task [13021901280636903736](https://jules.google.com/task/13021901280636903736) started by @xiahaa*