### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF bypass via IPv6-mapped IPv4 addresses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** Private IP checks relied on strict regex matching (e.g. `127.0.0.1`), allowing bypasses using alternative formats like `127.1`, octal, or hex IPs.
 **Learning:** Attackers can represent IPs in many valid formats that simple regexes miss. The browser/OS resolves them to the same target.
 **Prevention:** Normalize hostnames using `new URL(url).hostname` before applying security checks. This converts obscure formats (e.g. `0x7f.0.0.1`) to standard dotted-decimal notation.
+
+## 2025-05-22 - SSRF Bypass via IPv6-Mapped IPv4
+**Vulnerability:** Private IP checks bypassed using IPv6-mapped IPv4 addresses (e.g., `[::ffff:127.0.0.1]` or `[::ffff:7f00:1]`) which `new URL()` normalizes differently than standard IPv4.
+**Learning:** URL parsers may normalize IPv6-mapped addresses to compressed hex format, evading standard regex-based IPv4 blocklists.
+**Prevention:** Explicitly detect and decode IPv6-mapped IPv4 addresses (starting with `::ffff:`) back to dotted-decimal notation before applying IP allow/block lists.

--- a/services/website.repro.test.ts
+++ b/services/website.repro.test.ts
@@ -1,0 +1,16 @@
+
+import { describe, it, expect } from 'vitest';
+import { isPrivateHostname } from './website';
+
+describe('isPrivateHostname SSRF Bypass Reproduction', () => {
+  it('should identify IPv6-mapped IPv4 addresses as private', () => {
+    // These should fail before the fix
+    expect(isPrivateHostname('::ffff:127.0.0.1')).toBe(true);
+    expect(isPrivateHostname('[::ffff:127.0.0.1]')).toBe(true);
+  });
+
+  it('should identify IPv6-mapped private range addresses', () => {
+    expect(isPrivateHostname('[::ffff:192.168.1.1]')).toBe(true);
+    expect(isPrivateHostname('[::ffff:10.0.0.1]')).toBe(true);
+  });
+});

--- a/services/website.ts
+++ b/services/website.ts
@@ -65,11 +65,20 @@ export async function checkRobotsTxt(url: string): Promise<boolean> {
     const urlObj = new URL(url);
     const robotsUrl = `${urlObj.protocol}//${urlObj.host}/robots.txt`;
 
-    const response = await fetch(robotsUrl, {
-      headers: {
-        'User-Agent': 'ZhimaBot/1.0 (HR Analysis Tool; Respects robots.txt)'
-      }
-    });
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5000);
+
+    let response;
+    try {
+      response = await fetch(robotsUrl, {
+        headers: {
+          'User-Agent': 'ZhimaBot/1.0 (HR Analysis Tool; Respects robots.txt)'
+        },
+        signal: controller.signal
+      });
+    } finally {
+      clearTimeout(timeoutId);
+    }
 
     // If robots.txt doesn't exist (404), assume scraping is allowed
     if (response.status === 404) {
@@ -255,10 +264,37 @@ export function isPrivateHostname(hostname: string): boolean {
     return true;
   }
 
+  // Handle IPv6 mapped IPv4 (e.g., ::ffff:127.0.0.1)
+  // URL hostname usually includes brackets for IPv6: [::ffff:127.0.0.1]
+  let checkHostname = normalizedHostname;
+  if (checkHostname.startsWith('[') && checkHostname.endsWith(']')) {
+    checkHostname = checkHostname.slice(1, -1);
+  }
+
+  if (checkHostname.toLowerCase().startsWith('::ffff:')) {
+    const suffix = checkHostname.substring(7);
+    if (suffix.includes('.')) {
+       // Already dotted decimal
+       checkHostname = suffix;
+    } else {
+       // Hex format (e.g. 7f00:1), convert to dotted decimal
+       const parts = suffix.split(':');
+       if (parts.length === 2) {
+          const g1 = parseInt(parts[0], 16);
+          const g2 = parseInt(parts[1], 16);
+          const a = (g1 >> 8) & 0xff;
+          const b = g1 & 0xff;
+          const c = (g2 >> 8) & 0xff;
+          const d = g2 & 0xff;
+          checkHostname = `${a}.${b}.${c}.${d}`;
+       }
+    }
+  }
+
   // IPv4 check
   // Matches 1.2.3.4 format
   const ipv4Regex = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
-  const match = normalizedHostname.match(ipv4Regex);
+  const match = checkHostname.match(ipv4Regex);
 
   if (match) {
     const parts = match.slice(1).map(Number);
@@ -380,12 +416,21 @@ export async function fetchPersonalWebsite(url: string): Promise<WebsiteInfo | n
     }
 
     // Fetch the website content
-    const response = await fetch(validUrl, {
-      headers: {
-        'User-Agent': 'ZhimaBot/1.0 (HR Analysis Tool; Respects robots.txt)',
-        'Accept': 'text/html,application/xhtml+xml'
-      }
-    });
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5000);
+
+    let response;
+    try {
+      response = await fetch(validUrl, {
+        headers: {
+          'User-Agent': 'ZhimaBot/1.0 (HR Analysis Tool; Respects robots.txt)',
+          'Accept': 'text/html,application/xhtml+xml'
+        },
+        signal: controller.signal
+      });
+    } finally {
+      clearTimeout(timeoutId);
+    }
 
     if (!response.ok) {
       console.error(`Failed to fetch website ${validUrl}: ${response.status}`);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: SSRF protection in `isPrivateHostname` could be bypassed using IPv6-mapped IPv4 addresses (e.g., `[::ffff:127.0.0.1]`), which `new URL()` normalizes to hex-compressed format, evading the regex check.
🎯 Impact: Attackers could potentially access internal network resources (localhost, private IPs) via the personal website analysis feature.
🔧 Fix: Enhanced `isPrivateHostname` to detect and decode IPv6-mapped IPv4 addresses back to dotted-decimal notation before validation. Also added a 5-second timeout to external fetch requests for defense-in-depth against DoS.
✅ Verification: Added `services/website.repro.test.ts` which confirms the vulnerability is fixed. Ran full test suite.

---
*PR created automatically by Jules for task [9375010345252448421](https://jules.google.com/task/9375010345252448421) started by @xiahaa*