### PR TITLE
🎨 Palette: Improve JD Match form accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -21,3 +21,7 @@
 ## 2026-02-07 - [Visible Labels for Secondary Inputs]
 **Learning:** In minimalist "Bento" dark-mode forms, optional or secondary inputs (like scholar links or LinkedIn URLs) often omit labels for aesthetics, relying on placeholders. This hides context once the user starts typing and creates accessibility barriers.
 **Action:** Always provide visible `<label>` text for form inputs, using `text-sm text-gray-400 font-medium` to balance readability with the minimalist design.
+
+## 2026-02-21 - [Live Form Validation Accessibility]
+**Learning:** Dynamic validation errors that appear below inputs are often missed by screen readers if they don't have an appropriate role. Using `role="alert"` ensures immediate announcement of critical validation failures without moving focus.
+**Action:** Add `role="alert"` to container elements displaying dynamic form validation error messages.

--- a/components/JDMatch.tsx
+++ b/components/JDMatch.tsx
@@ -141,7 +141,11 @@ export const JDMatch: React.FC<JDMatchProps> = ({ onAnalyze }) => {
           {/* URL Input */}
           {inputMode === 'url' && (
             <div>
+              <label htmlFor="resumeUrl" className="block text-sm font-medium text-gray-400 mb-2">
+                简历链接 <span className="text-red-400">*</span>
+              </label>
               <input
+                id="resumeUrl"
                 type="text"
                 placeholder="简历链接（GitHub、LinkedIn或其他在线简历）"
                 className="w-full bg-white/5 border border-white/10 rounded-xl px-4 py-3 focus:outline-none focus:ring-2 focus:ring-[#2D5BFF]/50 focus:border-[#2D5BFF] transition-all text-base placeholder:text-gray-600"
@@ -185,7 +189,7 @@ export const JDMatch: React.FC<JDMatchProps> = ({ onAnalyze }) => {
 
         {/* Validation Error Message */}
         {validationError && (
-          <div className="bg-red-500/10 border border-red-500/20 rounded-xl px-4 py-3 text-red-400 text-sm">
+          <div role="alert" className="bg-red-500/10 border border-red-500/20 rounded-xl px-4 py-3 text-red-400 text-sm">
             {validationError}
           </div>
         )}


### PR DESCRIPTION
💡 **What:** Added a visible label to the "Resume URL" input in the JD Match form and added `role="alert"` to the validation error container.

🎯 **Why:**
- The "Resume URL" input was missing a visible label, relying only on a placeholder, which is an accessibility barrier (and inconsistent with other form fields).
- The validation error message appeared dynamically but lacked `role="alert"`, meaning screen readers might miss the critical feedback.

📸 **Visual Changes:**
- A "简历链接 *" label now appears above the resume URL input field, consistent with "Industry" and "Company Name" fields.

♿ **Accessibility:**
- Ensures the input has a programmatic and visual label.
- Ensures validation errors are announced immediately by screen readers.

---
*PR created automatically by Jules for task [10203515567546094384](https://jules.google.com/task/10203515567546094384) started by @xiahaa*