### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in JD Matcher and enhance IP validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -23,3 +23,8 @@
 **Prevention:** Implement a defense-in-depth approach:
 1. Block known localhost wildcard domains (nip.io, localtest.me).
 2. Recursively check hostnames for embedded IP patterns (e.g., 1-1-1-1.nip.io) to detect and block private IPs hidden in public domains.
+
+## 2026-02-18 - SSRF in JD Matcher & Integer IP Bypass
+**Vulnerability:** The JD Matcher feature allowed fetching arbitrary URLs (including localhost/private IPs) via `resumeUrl` because it only validated the protocol. Additionally, `isPrivateHostname` was vulnerable to integer IP formats (e.g., `2130706433`) in environments where `URL` normalization is inconsistent.
+**Learning:** New features often duplicate security logic (like URL validation) poorly instead of reusing robust centralized functions. Also, browser URL parsing behavior varies for non-standard IP formats.
+**Prevention:** Centralize all URL validation in `services/website.ts` and enforce its use. Explicitly handle integer/octal IP formats by converting to dotted-decimal before validation.

--- a/services/jdMatcher.security.test.ts
+++ b/services/jdMatcher.security.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { analyzeJDMatch } from './jdMatcher';
+import { JobDescription } from '../types';
+
+// Mock process.env
+vi.stubEnv('DEEPSEEK_API_KEY', 'test-key');
+
+// Mock pdf service to avoid loading pdfjs-dist which fails in node environment
+vi.mock('./pdf', () => ({
+  parsePDF: vi.fn(),
+  extractCandidateInfoFromPDF: vi.fn(),
+}));
+
+describe('JD Matcher Security (SSRF)', () => {
+  const mockJobDescription: JobDescription = {
+    industry: 'Tech',
+    companyName: 'Test Corp',
+    jobDescription: 'Software Engineer',
+  };
+
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should block access to localhost', async () => {
+    const jd = { ...mockJobDescription, resumeUrl: 'http://localhost/resume.txt' };
+
+    await expect(analyzeJDMatch(jd)).rejects.toThrow(/private network|blocked/i);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('should block access to 127.0.0.1', async () => {
+    const jd = { ...mockJobDescription, resumeUrl: 'http://127.0.0.1/resume.txt' };
+
+    await expect(analyzeJDMatch(jd)).rejects.toThrow(/private network|blocked/i);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('should block access to integer IPs (2130706433 -> 127.0.0.1)', async () => {
+    const jd = { ...mockJobDescription, resumeUrl: 'http://2130706433/resume.txt' };
+
+    await expect(analyzeJDMatch(jd)).rejects.toThrow(/private network|blocked/i);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('should block access to octal IPs (0177.0.0.1 -> 127.0.0.1)', async () => {
+    const jd = { ...mockJobDescription, resumeUrl: 'http://0177.0.0.1/resume.txt' };
+
+    await expect(analyzeJDMatch(jd)).rejects.toThrow(/private network|blocked/i);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('should block access to hex IPs (0x7f.0.0.1 -> 127.0.0.1)', async () => {
+     const jd = { ...mockJobDescription, resumeUrl: 'http://0x7f.0.0.1/resume.txt' };
+
+    await expect(analyzeJDMatch(jd)).rejects.toThrow(/private network|blocked/i);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('should block access to IPv6 localhost ([::1])', async () => {
+    const jd = { ...mockJobDescription, resumeUrl: 'http://[::1]/resume.txt' };
+
+    await expect(analyzeJDMatch(jd)).rejects.toThrow(/private network|blocked/i);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('should allow public URLs', async () => {
+    const jd = { ...mockJobDescription, resumeUrl: 'https://example.com/resume.txt' };
+
+    // Mock successful fetch
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => 'text/plain' },
+      text: async () => 'Resume content with enough length to pass the minimum requirement of 100 characters. '.repeat(5),
+    });
+
+    // Mock AI response
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: JSON.stringify({ overallScore: 80 }) } }]
+      })
+    });
+
+    const result = await analyzeJDMatch(jd);
+    expect(result).toBeDefined();
+    // Verify first fetch was to the resume URL
+    expect(global.fetch).toHaveBeenNthCalledWith(1, expect.stringContaining('example.com'), expect.anything());
+  });
+});

--- a/services/jdMatcher.ts
+++ b/services/jdMatcher.ts
@@ -1,5 +1,6 @@
 import { JobDescription, JDMatchResult, MatchScore } from "../types";
 import { parsePDF } from "./pdf";
+import { isPrivateHostname } from "./website";
 
 // Validation constants
 const MIN_RESUME_LENGTH = 100; // Minimum characters for valid resume content
@@ -72,6 +73,19 @@ async function fetchResumeFromUrl(url: string): Promise<string> {
   const sanitizedUrl = sanitizeUrl(url);
   if (!sanitizedUrl) {
     throw new Error('Invalid URL format');
+  }
+
+  // Security check: Block private network access (SSRF)
+  try {
+    const hostname = new URL(sanitizedUrl).hostname;
+    if (isPrivateHostname(hostname)) {
+      throw new Error('Access to private network resources is blocked.');
+    }
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('blocked')) {
+      throw err;
+    }
+    throw new Error('Invalid URL for security check');
   }
 
   const response = await fetch(sanitizedUrl, {

--- a/services/website.ts
+++ b/services/website.ts
@@ -339,6 +339,29 @@ export function isPrivateHostname(hostname: string): boolean {
     if (a === 0) return true;
   }
 
+  // Check for integer IP format (e.g., 2130706433 -> 127.0.0.1)
+  // Some browsers might not normalize this automatically
+  if (/^\d+$/.test(checkHostname)) {
+    try {
+      const ipInt = parseInt(checkHostname, 10);
+      if (!isNaN(ipInt) && ipInt >= 0 && ipInt <= 4294967295) {
+        // Convert to unsigned 32-bit integer logic
+        const a = (ipInt >>> 24) & 0xff;
+        const b = (ipInt >>> 16) & 0xff;
+        const c = (ipInt >>> 8) & 0xff;
+        const d = ipInt & 0xff;
+        const dotted = `${a}.${b}.${c}.${d}`;
+        // Recursively check the dotted decimal format
+        // Avoid infinite recursion if dotted equals checkHostname (unlikely for dotted vs int)
+        if (dotted !== checkHostname && isPrivateHostname(dotted)) {
+          return true;
+        }
+      }
+    } catch {
+      // Ignore parsing errors
+    }
+  }
+
   // Check for embedded IPs in hostname (e.g., 10-0-0-1.mycompany.com)
   // This helps catch DNS rebinding attempts or internal hostnames
   // We use a global regex to find ALL potential IP patterns


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: JD Matcher allowed fetching arbitrary URLs (including localhost/private IPs) via `resumeUrl` (SSRF). Additionally, `isPrivateHostname` was vulnerable to integer IP formats (e.g. `2130706433`).
🎯 Impact: Attackers could scan local network services or access internal metadata services via the victim's browser.
🔧 Fix:
1. Updated `services/website.ts` to detect and validate integer IP formats.
2. Updated `services/jdMatcher.ts` to enforce `isPrivateHostname` check before fetching resumes.
✅ Verification: Added `services/jdMatcher.security.test.ts` to verify blockage of private IPs (localhost, 127.0.0.1, integer, octal, hex).

---
*PR created automatically by Jules for task [2462728189702554577](https://jules.google.com/task/2462728189702554577) started by @xiahaa*