### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF via Redirects & XSS risk in JD Matcher

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -35,3 +35,8 @@
 **Prevention:**
 1. Use structured `system` and `user` roles in LLM API calls to separate instructions from data.
 2. Enforce strict character/size limits on user-provided content before processing or sending to external APIs.
+
+## 2026-02-10 - SSRF Bypass via Redirects
+**Vulnerability:** Client-side SSRF protection using `isPrivateHostname` was bypassed because `fetch` follows redirects by default. An attacker could use a public URL that redirects to a private IP (e.g. localhost) to scan the local network or access internal services.
+**Learning:** Validating the initial URL is insufficient. The HTTP client must also be configured to block redirects or validate the redirect target.
+**Prevention:** Use `redirect: 'error'` in `fetch` options for high-risk data retrieval to prevent the browser/client from silently following redirects to restricted networks.

--- a/services/jdMatcher.ssrf_redirect.test.ts
+++ b/services/jdMatcher.ssrf_redirect.test.ts
@@ -1,0 +1,74 @@
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { JobDescription } from '../types';
+
+// Mock pdf service to avoid loading pdfjs-dist which fails in Node env
+vi.mock('./pdf', () => ({
+  parsePDF: vi.fn(),
+  extractCandidateInfoFromPDF: vi.fn()
+}));
+
+// Mock mineru service
+vi.mock('./mineru', () => ({
+  extractWithMineru: vi.fn()
+}));
+
+import { analyzeJDMatch } from './jdMatcher';
+
+// Mock types
+const mockJD: JobDescription = {
+  id: '1',
+  companyName: 'Test Corp',
+  industry: 'Tech',
+  jobDescription: 'Looking for a developer',
+  requirements: [],
+  skills: [],
+  location: 'Remote',
+  salaryRange: '$100k',
+  postedDate: '2023-01-01',
+  resumeUrl: 'http://malicious.com/redirect'
+};
+
+describe('analyzeJDMatch Security', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.DEEPSEEK_API_KEY = 'test-key';
+
+    // Mock global fetch
+    global.fetch = vi.fn();
+
+    // Mock console.error/warn to keep output clean
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should prevent following redirects when fetching resume', async () => {
+    // We want to ensure that fetch is called with redirect: 'error'
+    // This prevents SSRF attacks where an external URL redirects to localhost/intranet
+
+    // Setup fetch mock to succeed initially (so we can check the call arguments)
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      headers: { get: () => 'text/plain' },
+      text: () => Promise.resolve('Resume content')
+    });
+
+    try {
+      await analyzeJDMatch(mockJD);
+    } catch (e) {
+      // Ignore errors from subsequent steps (AI analysis etc)
+    }
+
+    // Verify fetch was called with redirect: 'error'
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('http://malicious.com/redirect'),
+      expect.objectContaining({
+        redirect: 'error'
+      })
+    );
+  });
+});

--- a/services/jdMatcher.ts
+++ b/services/jdMatcher.ts
@@ -100,11 +100,21 @@ async function fetchResumeFromUrl(url: string): Promise<string> {
     throw new Error('Invalid URL for security check');
   }
 
-  const response = await fetch(sanitizedUrl, {
-    headers: {
-      'User-Agent': 'ZhimaBot/1.0 (HR JD Matcher; Contact: hr@zhima.ai)',
-    },
-  });
+  let response;
+  try {
+    response = await fetch(sanitizedUrl, {
+      headers: {
+        'User-Agent': 'ZhimaBot/1.0 (HR JD Matcher; Contact: hr@zhima.ai)',
+      },
+      redirect: 'error' // Security: Prevent following redirects to private networks
+    });
+  } catch (err) {
+    // Check if it's a redirect error or other fetch error
+    if (err instanceof TypeError && err.message.includes('redirect')) {
+      throw new Error('Redirects are not supported for security reasons. Please use the direct URL.');
+    }
+    throw err;
+  }
 
   if (!response.ok) {
     throw new Error(`Failed to fetch URL (status ${response.status})`);
@@ -358,14 +368,17 @@ function extractTextFromHtml(html: string): string {
   // Remove all remaining HTML tags (final safeguard)
   text = text.replace(/<[^>]*>/g, ' ');
   
-  // Decode HTML entities (safe because result is used for text analysis, not HTML rendering)
-  // Only decode common entities to avoid double-escaping issues
-  const tempDiv = typeof document !== 'undefined' ? document.createElement('div') : null;
-  if (tempDiv) {
-    tempDiv.innerHTML = text;
-    text = tempDiv.textContent || tempDiv.innerText || text;
+  // Decode HTML entities
+  // Use DOMParser if available for safe decoding without executing scripts
+  if (typeof DOMParser !== 'undefined') {
+    try {
+      const doc = new DOMParser().parseFromString(text, 'text/html');
+      text = doc.documentElement.textContent || text;
+    } catch (e) {
+      // Ignore parser errors and fall back to regex replacement
+    }
   } else {
-    // Fallback for non-browser environments
+    // Fallback for non-browser environments or if DOMParser is unavailable
     text = text.replace(/&nbsp;/g, ' ');
     text = text.replace(/&lt;/g, '<');
     text = text.replace(/&gt;/g, '>');


### PR DESCRIPTION
This PR addresses two security vulnerabilities in the JD Matcher service:

1.  **SSRF Bypass via Redirects**: The `fetchResumeFromUrl` function now explicitly sets `redirect: 'error'`. Previously, an attacker could provide a public URL that redirects to a private IP (e.g., localhost), bypassing the `isPrivateHostname` check on the initial URL. This prevents the application from unwittingly accessing local network resources.
2.  **Potential XSS via `innerHTML`**: The `extractTextFromHtml` function previously used `tempDiv.innerHTML` to decode HTML entities, which could execute malicious scripts if the input was not perfectly sanitized. This has been replaced with `DOMParser().parseFromString().documentElement.textContent`, which safely decodes entities without executing scripts.

A regression test `services/jdMatcher.ssrf_redirect.test.ts` has been added to verify the redirect blocking behavior.

---
*PR created automatically by Jules for task [568027953250178355](https://jules.google.com/task/568027953250178355) started by @xiahaa*