### PR TITLE
⚡ Bolt: Optimize fetchWithCache to avoid double JSON parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -35,3 +35,7 @@
 1. `String.matchAll` with a complex regex in a loop (like checking for IP patterns in hostnames) is expensive when run frequently on strings that clearly don't match (e.g. "google.com"). A simple pre-check (e.g. `/[0-9:]/`) can skip 99% of the work.
 2. Contrary to common wisdom, recursive string concatenation (`str += str`) in V8 for DOM text extraction was significantly faster (~30%) than array accumulation (`arr.push(str); arr.join('')`) for typical resume-sized DOM trees.
 **Action:** Always measure micro-optimizations. Implemented a fast-path check in `isPrivateHostname` which improved performance by ~50% for common domain names.
+
+## 2025-02-27 - Response Cloning Overhead
+**Learning:** Using `response.clone()` to cache a response body doubles the JSON parsing work (once for cache, once for the caller) and adds stream buffering overhead.
+**Action:** Read the body once (`await response.json()`), cache the data, and return a proxy object that mimics the `Response` interface but returns the pre-parsed data. This saves ~50% of parsing time.

--- a/services/github.test.ts
+++ b/services/github.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, vi, expect, beforeEach, afterEach } from 'vitest';
-import { aggregateLanguageStats } from './github';
+import { aggregateLanguageStats, fetchGitHubProfile } from './github';
 
 // Mock fetch globally
 const originalFetch = global.fetch;
@@ -125,5 +125,34 @@ describe('aggregateLanguageStats', () => {
     // Verify 5 fork repos were called
     const forkCalls = languageCalls.filter((c: any[]) => c[0].includes('fork-'));
     expect(forkCalls.length).toBe(5);
+  });
+
+  it('should fetch profile efficiently without cloning response', async () => {
+    const mockProfile = { login: 'testuser', name: 'Test User' };
+    const jsonSpy = vi.fn().mockResolvedValue(mockProfile);
+    const cloneSpy = vi.fn();
+
+    (global.fetch as any).mockImplementation(async (url: string) => {
+      if (url.includes('/users/testuser')) {
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          json: jsonSpy,
+          clone: cloneSpy.mockReturnValue({
+            json: async () => mockProfile
+          })
+        };
+      }
+      return { ok: false };
+    });
+
+    const result = await fetchGitHubProfile('testuser');
+
+    expect(result).toEqual(mockProfile);
+
+    // The optimization goal: read body once, do not clone
+    expect(jsonSpy).toHaveBeenCalledTimes(1);
+    expect(cloneSpy).not.toHaveBeenCalled();
   });
 });

--- a/services/github.ts
+++ b/services/github.ts
@@ -37,9 +37,8 @@ async function fetchWithCache(url: string, options: RequestInit = {}) {
   const response = await fetch(url, { ...options, headers });
 
   if (response.ok) {
-    // Clone response to read body and cache it
-    const clone = response.clone();
-    const data = await clone.json();
+    // Read body once and cache it
+    const data = await response.json();
     try {
       localStorage.setItem(cacheKey, JSON.stringify({
         timestamp: Date.now(),
@@ -49,7 +48,22 @@ async function fetchWithCache(url: string, options: RequestInit = {}) {
       // Ignore storage quota errors
       console.warn('Failed to cache GitHub response', e);
     }
-    return response;
+
+    // Return a proxy that mimics the Response object but with pre-fetched data
+    // This avoids double parsing (clone.json() + response.json())
+    return {
+      ok: true,
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+      url: response.url,
+      json: async () => data,
+      text: async () => JSON.stringify(data),
+      clone: () => ({
+        json: async () => data,
+        text: async () => JSON.stringify(data)
+      })
+    } as any;
   }
 
   return response;


### PR DESCRIPTION
Optimized `fetchWithCache` to avoid calling `response.clone()` and parsing JSON twice.
This reduces CPU usage and memory overhead for large GitHub API responses.
Added a regression test to verify the behavior.

---
*PR created automatically by Jules for task [4711188314788906091](https://jules.google.com/task/4711188314788906091) started by @xiahaa*