### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF bypass via short/hex IPv4 formats

### DIFF
--- a/services/website.ts
+++ b/services/website.ts
@@ -339,10 +339,10 @@ export function isPrivateHostname(hostname: string): boolean {
     }
   }
 
-  // IPv4 check with support for Hex/Octal formats
-  // Matches 1.2.3.4, 0x7f.0.0.1, 0177.0.0.1 formats
+  // IPv4 check with support for Hex/Octal and Short formats
+  // Matches 1.2.3.4, 127.1, 0x7f.1, 0177.0.0.1 formats
   const parts = checkHostname.split('.');
-  if (parts.length === 4) {
+  if (parts.length >= 1 && parts.length <= 4) {
     let isIp = true;
     const numericParts: number[] = [];
 
@@ -362,7 +362,7 @@ export function isPrivateHostname(hostname: string): boolean {
         val = parseInt(part, 10);
       }
 
-      if (isNaN(val) || val < 0 || val > 255) {
+      if (isNaN(val) || val < 0) {
         isIp = false;
         break;
       }
@@ -370,7 +370,25 @@ export function isPrivateHostname(hostname: string): boolean {
     }
 
     if (isIp) {
-      const [a, b] = numericParts;
+      let finalParts: number[] = [];
+
+      // Normalize to 4-part dotted decimal
+      if (numericParts.length === 4) {
+        finalParts = numericParts;
+      } else if (numericParts.length === 1) {
+        const val = numericParts[0];
+        finalParts = [(val >>> 24) & 0xff, (val >>> 16) & 0xff, (val >>> 8) & 0xff, val & 0xff];
+      } else if (numericParts.length === 2) {
+        // a.b -> a.0.0.b (b is the rest)
+        const [a, rest] = numericParts;
+        finalParts = [a, (rest >>> 16) & 0xff, (rest >>> 8) & 0xff, rest & 0xff];
+      } else if (numericParts.length === 3) {
+        // a.b.c -> a.b.0.c (c is the rest)
+        const [a, b, rest] = numericParts;
+        finalParts = [a, b, (rest >>> 8) & 0xff, rest & 0xff];
+      }
+
+      const [a, b] = finalParts;
 
       // 127.0.0.0/8 (Loopback)
       if (a === 127) return true;
@@ -389,29 +407,6 @@ export function isPrivateHostname(hostname: string): boolean {
 
       // 0.0.0.0/8 (Current network)
       if (a === 0) return true;
-    }
-  }
-
-  // Check for integer IP format (e.g., 2130706433 -> 127.0.0.1)
-  // Some browsers might not normalize this automatically
-  if (/^\d+$/.test(checkHostname)) {
-    try {
-      const ipInt = parseInt(checkHostname, 10);
-      if (!isNaN(ipInt) && ipInt >= 0 && ipInt <= 4294967295) {
-        // Convert to unsigned 32-bit integer logic
-        const a = (ipInt >>> 24) & 0xff;
-        const b = (ipInt >>> 16) & 0xff;
-        const c = (ipInt >>> 8) & 0xff;
-        const d = ipInt & 0xff;
-        const dotted = `${a}.${b}.${c}.${d}`;
-        // Recursively check the dotted decimal format
-        // Avoid infinite recursion if dotted equals checkHostname (unlikely for dotted vs int)
-        if (dotted !== checkHostname && isPrivateHostname(dotted)) {
-          return true;
-        }
-      }
-    } catch {
-      // Ignore parsing errors
     }
   }
 


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix SSRF bypass via short/hex IPv4 formats

🚨 Severity: HIGH
💡 Vulnerability: The previous `isPrivateHostname` function could be bypassed using short IPv4 formats (e.g., `127.1`) or hex/octal representations (e.g., `0x7f.1`) if the underlying URL parser did not normalize them. This allowed attackers to access local network resources (SSRF).
🎯 Impact: Attackers could potentially scan the internal network or access local services bound to localhost.
🔧 Fix: Implemented a robust IPv4 parsing logic that handles 1, 2, 3, or 4 dot-separated parts, supports hex/octal prefixes, and normalizes them to standard dotted-decimal format before checking against private IP ranges.
✅ Verification: Ran new reproduction tests confirming `127.1`, `0x7f.1`, and `0x7f000001` are now correctly blocked. Existing tests passed.

---
*PR created automatically by Jules for task [4959102681513149027](https://jules.google.com/task/4959102681513149027) started by @xiahaa*