### PR TITLE
🛡️ Sentinel: Fix SSRF bypass in isPrivateHostname

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -50,3 +50,8 @@
 **Vulnerability:** The application used regex-based HTML sanitization (`replace(/<script...>/)`) to extract text content, which is fragile and prone to bypasses (e.g., nested tags, malformed HTML).
 **Learning:** Regex is insufficient for parsing HTML securely. In browser environments, the native `DOMParser` API provides robust, standards-compliant parsing and sanitization that is far superior to regex.
 **Prevention:** Use `DOMParser` for HTML text extraction when available (browser), falling back to regex only in environments where DOM is absent (Node.js). Ideally, use a robust library like `jsdom` for consistent behavior across environments.
+
+## 2026-05-27 - SSRF Bypass via Obfuscated IP Patterns in Hostnames
+**Vulnerability:** The `isPrivateHostname` function used a strict regex `(\d{1,3})` to detect embedded IPs, which failed to capture 4-digit octal IPs (e.g., `0177`) or hexadecimal IPs (e.g., `0x7f`). This allowed attackers to bypass SSRF protection using domains like `0177.0.0.1.traefik.me`.
+**Learning:** Regex-based IP detection must account for all valid IP representations, including octal and hexadecimal formats, not just standard decimal notation.
+**Prevention:** Use a more inclusive regex for IP part detection (e.g., `[a-zA-Z0-9]+`) and rely on robust parsing logic to validate the extracted parts as private IPs.

--- a/services/website.ssrf_extended.test.ts
+++ b/services/website.ssrf_extended.test.ts
@@ -1,0 +1,22 @@
+
+import { describe, it, expect } from 'vitest';
+import { isPrivateHostname } from './website';
+
+describe('isPrivateHostname SSRF Bypass Extended', () => {
+  it('should identify octal IPs in hostnames', () => {
+    // 0177.0.0.1 is 127.0.0.1
+    // The previous regex (\d{1,3}) failed on 0177 (4 digits)
+    expect(isPrivateHostname('0177.0.0.1.nip.io')).toBe(true);
+    expect(isPrivateHostname('0177.0.0.1.traefik.me')).toBe(true);
+  });
+
+  it('should identify hex IPs in hostnames', () => {
+    // 0x7f.0.0.1 is 127.0.0.1
+    // The previous regex (\d) failed on 'x'
+    expect(isPrivateHostname('0x7f.0.0.1.traefik.me')).toBe(true);
+  });
+
+  it('should identify mixed hex/decimal IPs', () => {
+    expect(isPrivateHostname('127.0.0.0x1.traefik.me')).toBe(true);
+  });
+});

--- a/services/website.ts
+++ b/services/website.ts
@@ -437,7 +437,8 @@ export function isPrivateHostname(hostname: string): boolean {
   // Check for embedded IPs in hostname (e.g., 10-0-0-1.mycompany.com)
   // This helps catch DNS rebinding attempts or internal hostnames
   // We use a global regex to find ALL potential IP patterns
-  const ipPattern = /(\d{1,3})[\.-](\d{1,3})[\.-](\d{1,3})[\.-](\d{1,3})/g;
+  // Improved regex to capture hex/octal parts (alphanumeric) and longer sequences
+  const ipPattern = /([a-zA-Z0-9]+)[\.-]([a-zA-Z0-9]+)[\.-]([a-zA-Z0-9]+)[\.-]([a-zA-Z0-9]+)/g;
   const matches = checkHostname.matchAll(ipPattern);
 
   for (const match of matches) {


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix SSRF Bypass via Obfuscated IP Patterns

🚨 Severity: CRITICAL
💡 Vulnerability: The `isPrivateHostname` function used a strict regex `(\d{1,3})` to detect embedded IPs, which failed to capture 4-digit octal IPs (e.g., `0177`) or hexadecimal IPs (e.g., `0x7f`). This allowed attackers to bypass SSRF protection using domains like `0177.0.0.1.traefik.me`.
🎯 Impact: An attacker could trick the application into fetching content from internal network resources (localhost, private IPs) by obfuscating the IP address in the hostname.
🔧 Fix: Updated the regex in `services/website.ts` to capture alphanumeric IP parts (supporting hex/octal) and validate them recursively.
✅ Verification: Added `services/website.ssrf_extended.test.ts` which confirms that `0177.0.0.1` and `0x7f.0.0.1` are now correctly blocked. Ran full test suite to ensure no regressions.

---
*PR created automatically by Jules for task [15022878493596789594](https://jules.google.com/task/15022878493596789594) started by @xiahaa*