### PR TITLE
🛡️ Sentinel: Fix SSRF bypass for short IP formats

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -55,3 +55,11 @@
 **Vulnerability:** The `isPrivateHostname` function used a strict regex `(\d{1,3})` to detect embedded IPs, which failed to capture 4-digit octal IPs (e.g., `0177`) or hexadecimal IPs (e.g., `0x7f`). This allowed attackers to bypass SSRF protection using domains like `0177.0.0.1.traefik.me`.
 **Learning:** Regex-based IP detection must account for all valid IP representations, including octal and hexadecimal formats, not just standard decimal notation.
 **Prevention:** Use a more inclusive regex for IP part detection (e.g., `[a-zA-Z0-9]+`) and rely on robust parsing logic to validate the extracted parts as private IPs.
+
+## 2026-05-27 - Infinite Recursion in SSRF Check & Short IP Bypass
+**Vulnerability:** `isPrivateHostname` relied on a strict 4-part regex for embedded IPs, missing short IPs (e.g., `127.1`). A proposed fix introduced infinite recursion because URL normalization expands short IPs (e.g., `8.0` -> `8.0.0.0`), which then re-trigger the check.
+**Learning:** Recursive validation logic must account for data normalization cycles. Also, valid Public IPs can sometimes contain substrings that look like Private IPs (e.g. `8.8.8.8` containing `0.0` after normalization), leading to false positives if not handled carefully.
+**Prevention:**
+1. Use a "split and scan" strategy for embedded IPs with support for short formats (2-4 parts).
+2. Explicitly prevent recursion if the normalized candidate matches the input.
+3. Exit early if the input is already confirmed as a valid Public IP to avoid scanning it for false-positive embedded patterns.

--- a/services/website.ts
+++ b/services/website.ts
@@ -431,22 +431,53 @@ export function isPrivateHostname(hostname: string): boolean {
 
       // 0.0.0.0/8 (Current network)
       if (a === 0) return true;
+
+      // If we reached here, it means the hostname was parsed as a valid IPv4 address
+      // and it did NOT match any private ranges. Thus, it is a public IP.
+      // We should return false immediately to avoid false positives in the embedded IP check
+      // (e.g. 8.8.8.8 contains "8.8" -> "8.0.0.8" -> contains "0.0" -> Private)
+      return false;
     }
   }
 
   // Check for embedded IPs in hostname (e.g., 10-0-0-1.mycompany.com)
   // This helps catch DNS rebinding attempts or internal hostnames
-  // We use a global regex to find ALL potential IP patterns
-  // Improved regex to capture hex/octal parts (alphanumeric) and longer sequences
-  const ipPattern = /([a-zA-Z0-9]+)[\.-]([a-zA-Z0-9]+)[\.-]([a-zA-Z0-9]+)[\.-]([a-zA-Z0-9]+)/g;
-  const matches = checkHostname.matchAll(ipPattern);
+  // We check sequences of parts that could form an IP address (2-4 parts)
+  {
+    // Split by common delimiters (dots and dashes) to isolate potential IP parts
+    const embeddedParts = checkHostname.split(/[\.-]/);
 
-  for (const match of matches) {
-    const ip = `${match[1]}.${match[2]}.${match[3]}.${match[4]}`;
-    // Recursively check the extracted IP
-    // Note: strict check to avoid infinite recursion if something weird happens
-    if (ip !== checkHostname && isPrivateHostname(ip)) {
-      return true;
+    // Iterate over all possible subsequences of length 2 to 4
+    // We skip single parts (length 1) to avoid false positives on simple numbers like "node-1"
+    // while catching short IP forms like "127.1"
+    for (let i = 0; i < embeddedParts.length; i++) {
+      for (let len = 2; len <= 4; len++) {
+        if (i + len > embeddedParts.length) break;
+
+        const subParts = embeddedParts.slice(i, i + len);
+        const ip = subParts.join('.');
+
+        // Recursively check the extracted candidate IP
+        // isPrivateHostname handles validation (must be numeric/hex/octal)
+        if (ip !== checkHostname) {
+          // Prevent infinite recursion due to URL normalization (e.g. 8.0 -> 8.0.0.0)
+          // If the candidate IP normalizes to the current checkHostname, we skip it
+          // because the main logic of the current function call already handles it.
+          let normalizedCandidate = ip;
+          try {
+            // Use URL parser to normalize potential IP
+            normalizedCandidate = new URL(`http://${ip}`).hostname;
+          } catch {
+            // If invalid URL, ignore normalization check
+          }
+
+          if (normalizedCandidate !== checkHostname) {
+            if (isPrivateHostname(ip)) {
+              return true;
+            }
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
This patch fixes a potential SSRF bypass where attackers could use short IP formats (e.g. `127.1` in `127.1.traefik.me`) to evade the embedded IP check. It also hardens the validation logic against recursion and false positives.

---
*PR created automatically by Jules for task [8914440782721211389](https://jules.google.com/task/8914440782721211389) started by @xiahaa*