### PR TITLE
🛡️ Sentinel: [HIGH] Prevent SSRF via redirect following in website scraper

### DIFF
--- a/services/website.security.test.ts
+++ b/services/website.security.test.ts
@@ -1,0 +1,58 @@
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fetchPersonalWebsite, checkRobotsTxt } from './website';
+
+describe('website.ts SSRF Security', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    global.fetch = vi.fn();
+    // Mock URL to avoid network calls if any leak
+    // but we use vi.fn() for fetch so it should be safe
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetchPersonalWebsite should prevent following redirects', async () => {
+    // Mock robots.txt check to pass (404 means allowed)
+    (global.fetch as any).mockResolvedValueOnce({
+      status: 404,
+      ok: false
+    });
+
+    // Mock website fetch to succeed initially (to check arguments)
+    (global.fetch as any).mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      text: async () => '<html></html>'
+    });
+
+    await fetchPersonalWebsite('https://example.com');
+
+    // Verify fetch was called with redirect: 'error'
+    expect(global.fetch).toHaveBeenLastCalledWith(
+      expect.stringContaining('https://example.com'),
+      expect.objectContaining({
+        redirect: 'error'
+      })
+    );
+  });
+
+  it('checkRobotsTxt should prevent following redirects', async () => {
+    (global.fetch as any).mockResolvedValue({
+      status: 200,
+      ok: true,
+      text: async () => 'User-agent: *'
+    });
+
+    await checkRobotsTxt('https://example.com');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/robots.txt'),
+      expect.objectContaining({
+        redirect: 'error'
+      })
+    );
+  });
+});

--- a/services/website.ts
+++ b/services/website.ts
@@ -74,7 +74,8 @@ export async function checkRobotsTxt(url: string): Promise<boolean> {
         headers: {
           'User-Agent': 'ZhimaBot/1.0 (HR Analysis Tool; Respects robots.txt)'
         },
-        signal: controller.signal
+        signal: controller.signal,
+        redirect: 'error' // Security: Prevent following redirects to private networks
       });
     } finally {
       clearTimeout(timeoutId);
@@ -585,7 +586,8 @@ export async function fetchPersonalWebsite(url: string): Promise<WebsiteInfo | n
           'User-Agent': 'ZhimaBot/1.0 (HR Analysis Tool; Respects robots.txt)',
           'Accept': 'text/html,application/xhtml+xml'
         },
-        signal: controller.signal
+        signal: controller.signal,
+        redirect: 'error' // Security: Prevent following redirects to private networks
       });
     } finally {
       clearTimeout(timeoutId);


### PR DESCRIPTION
This PR addresses a HIGH severity security issue where the application's website scraper could be tricked into accessing internal network resources (SSRF) by following HTTP redirects.

**Vulnerability:**
The `fetchPersonalWebsite` and `checkRobotsTxt` functions in `services/website.ts` validated the initial URL against private IP ranges but did not prevent `fetch` from following redirects. An attacker could provide a public URL that redirects to a private IP (e.g., `localhost`), bypassing the initial check.

**Fix:**
Added `redirect: 'error'` to the `fetch` options in both functions. This causes the request to fail if a redirect is encountered, preventing the browser/client from accessing the redirect target.

**Verification:**
Added `services/website.security.test.ts` which mocks `fetch` and asserts that the `redirect: 'error'` option is passed.

**Impact:**
- Significantly reduces SSRF risk.
- **Trade-off:** Legitimate personal websites that use redirects (e.g., `http` -> `https`, or domain forwarding) will now fail to load. This is an intentional "fail closed" security decision. Users should provide the final destination URL.

---
*PR created automatically by Jules for task [1752405642471183270](https://jules.google.com/task/1752405642471183270) started by @xiahaa*