### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF via redirects in website analysis

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -63,3 +63,8 @@
 1. Use a "split and scan" strategy for embedded IPs with support for short formats (2-4 parts).
 2. Explicitly prevent recursion if the normalized candidate matches the input.
 3. Exit early if the input is already confirmed as a valid Public IP to avoid scanning it for false-positive embedded patterns.
+
+## 2026-06-15 - SSRF via Redirects in Personal Website Fetch
+**Vulnerability:** The `fetchPersonalWebsite` and `checkRobotsTxt` functions used `fetch` without `redirect: 'error'`, allowing attackers to bypass URL validation by redirecting from a public URL to a private IP (SSRF).
+**Learning:** URL validation at the application layer is insufficient for preventing SSRF if the HTTP client automatically follows redirects.
+**Prevention:** Always use `redirect: 'error'` in `fetch` calls when retrieving content from user-provided URLs to prevent the client from silently following redirects to restricted networks.

--- a/services/website.redirect.test.ts
+++ b/services/website.redirect.test.ts
@@ -1,0 +1,51 @@
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { checkRobotsTxt, fetchPersonalWebsite } from './website';
+
+describe('website.ts SSRF Redirect Protection', () => {
+  beforeEach(() => {
+    // Mock global fetch
+    global.fetch = vi.fn();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('checkRobotsTxt should prevent following redirects', async () => {
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve('User-agent: *\nDisallow: /'),
+      status: 200
+    });
+
+    await checkRobotsTxt('https://example.com');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('robots.txt'),
+      expect.objectContaining({
+        redirect: 'error'
+      })
+    );
+  });
+
+  it('fetchPersonalWebsite should prevent following redirects', async () => {
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve('<html><body>Content</body></html>'),
+      status: 200,
+      headers: { get: () => 'text/html' }
+    });
+
+    await fetchPersonalWebsite('https://example.com');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        redirect: 'error'
+      })
+    );
+  });
+});

--- a/services/website.ts
+++ b/services/website.ts
@@ -74,7 +74,8 @@ export async function checkRobotsTxt(url: string): Promise<boolean> {
         headers: {
           'User-Agent': 'ZhimaBot/1.0 (HR Analysis Tool; Respects robots.txt)'
         },
-        signal: controller.signal
+        signal: controller.signal,
+        redirect: 'error' // Security: Prevent following redirects to private networks
       });
     } finally {
       clearTimeout(timeoutId);
@@ -585,7 +586,8 @@ export async function fetchPersonalWebsite(url: string): Promise<WebsiteInfo | n
           'User-Agent': 'ZhimaBot/1.0 (HR Analysis Tool; Respects robots.txt)',
           'Accept': 'text/html,application/xhtml+xml'
         },
-        signal: controller.signal
+        signal: controller.signal,
+        redirect: 'error' // Security: Prevent following redirects to private networks
       });
     } finally {
       clearTimeout(timeoutId);


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `fetchPersonalWebsite` and `checkRobotsTxt` functions used `fetch` without `redirect: 'error'`, allowing attackers to bypass initial URL validation (which blocks private IPs) by redirecting from a public URL to a private IP (SSRF).
🎯 Impact: Attackers could scan local network ports or access internal services (like `localhost:3000`) if the user is tricked into analyzing a malicious URL.
🔧 Fix: Added `redirect: 'error'` to `fetch` options in `services/website.ts`. This ensures the browser/client throws an error instead of following redirects to potentially restricted networks.
✅ Verification: Created `services/website.redirect.test.ts` which asserts that `fetch` is called with `redirect: 'error'`. Ran full test suite.

---
*PR created automatically by Jules for task [9321897796708464180](https://jules.google.com/task/9321897796708464180) started by @xiahaa*