### PR TITLE
🛡️ Sentinel: Fix IPv6 SSRF Bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -74,3 +74,7 @@
 **Learning:** URL validation at the application layer is insufficient for preventing SSRF if the HTTP client automatically follows redirects.
 **Prevention:** Always use `redirect: 'error'` in `fetch` calls when retrieving content from user-provided URLs to prevent the client from silently following redirects to restricted networks.
 
+## 2026-07-20 - SSRF Bypass via Expanded IPv6
+**Vulnerability:** The `isPrivateHostname` function failed to block expanded IPv6 loopback (`0:0:0:0:0:0:0:1`) and unspecified (`0:0:0:0:0:0:0:0`) addresses because it only checked for compressed forms like `::1` or `::`.
+**Learning:** IPv6 addresses have multiple valid string representations (compressed, fully expanded, leading zeros). Security checks must handle all variations.
+**Prevention:** Implement checks for expanded IPv6 forms by splitting segments and verifying if they are all zero (or all zero + last one 1), rather than relying on strict string matching.

--- a/services/website.test.ts
+++ b/services/website.test.ts
@@ -21,6 +21,12 @@ describe('isPrivateHostname', () => {
     expect(isPrivateHostname('10.0.0.1')).toBe(true);
     expect(isPrivateHostname('169.254.1.1')).toBe(true);
     expect(isPrivateHostname('[::1]')).toBe(true);
+    expect(isPrivateHostname('::1')).toBe(true);
+    expect(isPrivateHostname('0:0:0:0:0:0:0:1')).toBe(true);
+    expect(isPrivateHostname('[0:0:0:0:0:0:0:1]')).toBe(true);
+    expect(isPrivateHostname('0000:0000:0000:0000:0000:0000:0000:0001')).toBe(true);
+    expect(isPrivateHostname('::')).toBe(true);
+    expect(isPrivateHostname('0:0:0:0:0:0:0:0')).toBe(true);
   });
 
   it('should identify alternative IPv4 formats as private', () => {

--- a/services/website.ts
+++ b/services/website.ts
@@ -361,6 +361,27 @@ export function isPrivateHostname(hostname: string, allowEmbeddedCheck: boolean 
     if (checkHostname === '::') {
       return true;
     }
+
+    // Check for expanded Loopback (e.g. 0:0:0:0:0:0:0:1) and Unspecified (e.g. 0:0:0:0:0:0:0:0)
+    // This catches variations like 0000:0000:0000:0000:0000:0000:0000:0001 which are not caught by strict string matching
+    const parts = checkHostname.split(':');
+    if (parts.length > 2) {
+      const isZero = (s: string) => !s || /^0+$/.test(s);
+
+      // Check if all parts are zero (Unspecified address ::)
+      if (parts.every(isZero)) {
+        return true;
+      }
+
+      // Check if it's a Loopback address (::1) where all but last part are zero, and last part is 1
+      const lastPart = parts[parts.length - 1];
+      const otherParts = parts.slice(0, -1);
+
+      // Check last part equals 1 (handling leading zeros e.g. 0001)
+      if (/^0*1$/.test(lastPart) && otherParts.every(isZero)) {
+        return true;
+      }
+    }
   }
 
   // OPTIMIZATION: Fast path - if no digits and no colons, it cannot be an IP address or contain an IP pattern.


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix SSRF bypass via expanded IPv6 addresses

**Severity:** HIGH
**Vulnerability:** The `isPrivateHostname` check could be bypassed using fully expanded IPv6 loopback addresses (e.g., `0:0:0:0:0:0:0:1`) or zero-padded variations, which were not caught by the existing strict string matching for `::1`.
**Impact:** Attackers could trick the application into fetching content from local services (localhost) on IPv6-enabled environments, potentially exposing internal data or services.
**Fix:** Implemented logic to parse and validate IPv6 segments, checking for "all zeros" (Unspecified) or "all zeros except last 1" (Loopback) patterns, regardless of string representation.
**Verification:** Added comprehensive test cases in `services/website.test.ts` covering expanded, compressed, and mixed IPv6 formats. ran `pnpm test services/website.test.ts` to verify.

---
*PR created automatically by Jules for task [13188994892619421626](https://jules.google.com/task/13188994892619421626) started by @xiahaa*