### PR TITLE
🎨 Palette: Add Paste button to GitHub URL input

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -41,3 +41,7 @@
 ## 2026-05-20 - [Semantic File Input Structure]
 **Learning:** Nesting interactive elements (like a clear button) inside a `<label>` linked to a file input is invalid HTML and confuses screen readers. A robust pattern uses an absolute overlay label for the trigger and positions sibling buttons (e.g., Clear) above it with z-index.
 **Action:** Refactor custom file inputs to use a container `div` with a sibling `label` (overlay) and `button` (z-indexed), avoiding nested interactive controls.
+
+## 2026-05-22 - [Empty State Action Buttons]
+**Learning:** Empty input fields are prime real estate for "accelerator" actions. Replacing the "Clear" button (which is useless when empty) with a "Paste" button reduces friction significantly for URL inputs.
+**Action:** Implement context-aware action buttons inside inputs (e.g., Paste when empty, Clear when filled) to improve efficiency.

--- a/components/Landing.tsx
+++ b/components/Landing.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from 'react';
-import { Upload, X } from 'lucide-react';
+import { Upload, X, Clipboard } from 'lucide-react';
 
 interface LandingProps {
   onAnalyze: (githubUrl: string, scholarUrl?: string, linkedinText?: string, personalWebsiteUrl?: string, pdfFile?: File) => void;
@@ -29,6 +29,18 @@ export const Landing: React.FC<LandingProps> = ({ onAnalyze }) => {
   const handleClearGithubUrl = () => {
     setGithubUrl('');
     githubInputRef.current?.focus();
+  };
+
+  const handlePaste = async () => {
+    try {
+      const text = await navigator.clipboard.readText();
+      if (text) {
+        setGithubUrl(text);
+        githubInputRef.current?.focus();
+      }
+    } catch (err) {
+      console.error('Failed to read clipboard:', err);
+    }
   };
 
   const handleClearFile = (e: React.MouseEvent) => {
@@ -106,11 +118,23 @@ export const Landing: React.FC<LandingProps> = ({ onAnalyze }) => {
               id="github-url"
               type="text"
               required
+              autoFocus
               placeholder="GitHub URL（例如 github.com/torvalds）"
               className="w-full bg-white/5 border border-white/10 rounded-2xl pl-6 pr-48 py-5 focus:outline-none focus:ring-2 focus:ring-[#2D5BFF]/50 focus:border-[#2D5BFF] transition-all text-xl placeholder:text-gray-600"
               value={githubUrl}
               onChange={(e) => setGithubUrl(e.target.value)}
             />
+            {!githubUrl && (
+              <button
+                type="button"
+                onClick={handlePaste}
+                aria-label="粘贴 GitHub URL"
+                title="从剪贴板粘贴"
+                className="absolute right-36 top-1/2 -translate-y-1/2 p-2 text-gray-400 hover:text-white transition-colors rounded-full hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2D5BFF]"
+              >
+                <Clipboard className="w-5 h-5" />
+              </button>
+            )}
             {githubUrl && (
               <button
                 type="button"


### PR DESCRIPTION
This PR enhances the UX of the Landing page by adding a "Paste" button to the GitHub URL input field. 

**Changes:**
1.  **Paste Button**: When the input is empty, a Paste button appears (replacing the Clear button position). It uses `navigator.clipboard.readText()` to quickly fill the input.
2.  **AutoFocus**: The input now automatically focuses on page load, saving a click.

**UX/Accessibility:**
-   The Paste button has `aria-label` and `title`.
-   The Paste button is keyboard accessible.
-   The "Empty State Action Button" pattern reduces friction for the primary action.

**Verification:**
-   Verified manually with Playwright script (screenshots confirmed visibility and focus).
-   Ran `pnpm build` and `pnpm test` successfully.


---
*PR created automatically by Jules for task [890457777763207109](https://jules.google.com/task/890457777763207109) started by @xiahaa*