### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix SSRF risk with dotless domains

### DIFF
--- a/services/website.security_dotless.test.ts
+++ b/services/website.security_dotless.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { isPrivateHostname } from './website';
+
+describe('isPrivateHostname Security Check', () => {
+  it('should identify dotless domains as private (potential internal network)', () => {
+    // These should return TRUE (private), but currently likely return FALSE (public)
+    expect(isPrivateHostname('intranet')).toBe(true);
+    expect(isPrivateHostname('corp')).toBe(true);
+    expect(isPrivateHostname('database')).toBe(true);
+    expect(isPrivateHostname('go')).toBe(true);
+  });
+});

--- a/services/website.ts
+++ b/services/website.ts
@@ -308,6 +308,13 @@ export function isPrivateHostname(hostname: string, allowEmbeddedCheck: boolean 
     return true;
   }
 
+  // Block dotless domains (single-label domains like "intranet", "corp", "database")
+  // These are typically local network names and should not be accessed from the public internet context.
+  // Exception: IPv6 addresses contain colons, so we ensure it's not an IPv6 address before blocking.
+  if (!normalizedHostname.includes('.') && !normalizedHostname.includes(':')) {
+    return true;
+  }
+
   // Block known DNS rebinding / localhost wildcard services
   const localhostDomains = [
     'localtest.me',


### PR DESCRIPTION
Enhanced isPrivateHostname to block dotless domains (single-label hostnames like 'intranet', 'corp', 'database') to prevent access to local network resources. Added regression test 'services/website.security_dotless.test.ts'.

---
*PR created automatically by Jules for task [4300042583708585212](https://jules.google.com/task/4300042583708585212) started by @xiahaa*