### PR TITLE
🛡️ [auto-fix] 修复 GitHub 服务中的类型安全问题

### DIFF
--- a/services/analyzer.ts
+++ b/services/analyzer.ts
@@ -1,5 +1,6 @@
 
 import { CandidateProfile, TechStackItem, PersonalWebsiteData, PDFResumeData } from "../types";
+import type { GitHubRepository } from "./github.types";
 import {
   fetchGitHubProfile,
   fetchGitHubRepos,
@@ -355,7 +356,7 @@ export async function analyzeCandidate(
 
   // 3. Prepare enhanced context for LLM
   const sortedRepos = (reposData || [])
-    .sort((a: any, b: any) => b.stargazers_count - a.stargazers_count)
+    .sort((a: GitHubRepository, b: GitHubRepository) => b.stargazers_count - a.stargazers_count)
     .slice(0, 20); // Top 20 by stars for quality signal
 
   const context = {
@@ -367,7 +368,7 @@ export async function analyzeCandidate(
     followers: profileData.followers || 0,
     following: profileData.following || 0,
     publicRepos: profileData.public_repos || 0,
-    repos: sortedRepos.map((r: any) => ({
+    repos: sortedRepos.map((r: GitHubRepository) => ({
       name: r.name,
       description: r.description,
       language: r.language,
@@ -443,7 +444,7 @@ export async function analyzeCandidate(
       },
       numPages: pdfResult.rawData.numPages
     } : null,
-    topRepositories: sortedRepos.slice(0, 6).map((r: any) => ({
+    topRepositories: sortedRepos.slice(0, 6).map((r: GitHubRepository) => ({
       name: r.name,
       description: r.description,
       stars: r.stargazers_count,

--- a/services/github.ts
+++ b/services/github.ts
@@ -1,4 +1,6 @@
 
+import type { GitHubRepository, AggregatedLanguageStats, TechStackItem } from './github.types';
+
 const CACHE_TTL = 3600 * 1000; // 1 hour
 
 function getGitHubToken() {
@@ -65,7 +67,7 @@ async function fetchWithCache(url: string, options: RequestInit = {}) {
         json: async () => data,
         text: async () => JSON.stringify(data)
       })
-    } as any;
+    } as Response;
   }
 
   return response;
@@ -111,7 +113,7 @@ export async function fetchRepoLanguages(username: string, repoName: string) {
 /**
  * Aggregates language usage across all repositories to calculate tech proficiency
  */
-export async function aggregateLanguageStats(username: string, repos: any[]) {
+export async function aggregateLanguageStats(username: string, repos: GitHubRepository[]): Promise<AggregatedLanguageStats> {
   const languageStats: Record<string, number> = {};
   const repoCount: Record<string, number> = {};
 
@@ -122,7 +124,7 @@ export async function aggregateLanguageStats(username: string, repos: any[]) {
   // Process top repositories to get language data
   // Prioritize non-fork repos and limit to top 10-15 to speed up analysis
   // OPTIMIZATION: Use single-pass loop with early exit instead of multiple filters
-  const topRepos: any[] = [];
+  const topRepos: GitHubRepository[] = [];
 
   // 1. Add source repos (prioritized)
   for (const repo of repos) {

--- a/services/github.types.ts
+++ b/services/github.types.ts
@@ -1,0 +1,66 @@
+/**
+ * GitHub API 类型定义
+ * 用于替代 any 类型，提供类型安全
+ */
+
+export interface GitHubRepository {
+  id: number;
+  name: string;
+  full_name: string;
+  description: string | null;
+  language: string | null;
+  stargazers_count: number;
+  forks_count: number;
+  open_issues_count: number;
+  updated_at: string;
+  pushed_at: string;
+  fork: boolean;
+  homepage: string | null;
+  license: {
+    spdx_id: string | null;
+  } | null;
+  html_url: string;
+}
+
+export interface GitHubUserProfile {
+  login: string;
+  id: number;
+  avatar_url: string;
+  name: string | null;
+  bio: string | null;
+  company: string | null;
+  blog: string | null;
+  location: string | null;
+  email: string | null;
+  followers: number;
+  following: number;
+  public_repos: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface GitHubEvent {
+  id: string;
+  type: string;
+  payload: {
+    commits?: Array<{
+      author?: {
+        email?: string;
+      };
+    }>;
+  };
+}
+
+export interface GitHubLanguageStats {
+  [language: string]: number;
+}
+
+export interface AggregatedLanguageStats {
+  languageStats: GitHubLanguageStats;
+  repoCount: Record<string, number>;
+}
+
+export interface TechStackItem {
+  name: string;
+  score: number;
+}


### PR DESCRIPTION
## 修复内容

此 PR 修复了 issue #107 中提到的类型安全问题。

### 变更详情

1. **新增类型定义文件** (`services/github.types.ts`)
   - 定义 `GitHubRepository` 接口
   - 定义 `GitHubUserProfile` 接口
   - 定义 `GitHubEvent` 接口
   - 定义 `GitHubLanguageStats` 类型
   - 定义 `AggregatedLanguageStats` 接口
   - 定义 `TechStackItem` 接口

2. **修复 `services/github.ts`**
   - 将 `as any` 改为 `as Response`
   - 更新 `aggregateLanguageStats` 函数参数类型为 `GitHubRepository[]`
   - 更新函数返回类型为 `Promise<AggregatedLanguageStats>`

3. **修复 `services/analyzer.ts`**
   - 导入 `GitHubRepository` 类型
   - 替换排序回调中的 `any` 类型为 `GitHubRepository`
   - 替换 `map` 回调中的 `any` 类型为 `GitHubRepository`

### 类型安全改进

- ✅ 移除 4 处 `any` 类型使用
- ✅ 添加完整的类型注解
- ✅ 提高代码可维护性和 IDE 支持
- ✅ 减少运行时类型错误风险

### 测试

- [ ] 类型检查通过
- [ ] 功能测试通过

---
*此 PR 由 Kimi Coder 自动修复流程创建*

Fixes #107